### PR TITLE
Fix issue when composed cache receive value was called twice

### DIFF
--- a/Sources/Carlos/CacheLevels/Composed.swift
+++ b/Sources/Carlos/CacheLevels/Composed.swift
@@ -28,10 +28,11 @@ extension CacheLevel {
           }.eraseToAnyPublisher()
       },
       setClosure: { value, key in
-        Publishers.Merge(
+        Publishers.Zip(
           self.set(value, forKey: key),
           cache.set(value, forKey: key)
         )
+        .map { _ in () }
         .eraseToAnyPublisher()
       },
       clearClosure: {


### PR DESCRIPTION
## Context
`Composed` cache was calling `receiveValue` twice or more depending on the number of composed cache levels.

This kind of behavior doesn't really make sense cuz most of the clients will expect `receiveValue` being called only once once all the cache levels finished caching operation. 

The issue has happened because of the usage of `Merge` operator instead of `Zip` operator. 