### PR TITLE
Feature: Remove value from cache 

### DIFF
--- a/Carlos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Carlos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
-          "version": "8.1.1"
+          "revision": "af1730dde4e6c0d45bf01b99f8a41713ce536790",
+          "version": "9.2.0"
         }
       },
       {
@@ -15,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0038bcbab4292f3b028632556507c124e5ba69f3",
-          "version": "3.0.0"
+          "revision": "bd86ca0141e3cfb333546de5a11ede63f0c4a0e6",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
-    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.1.0"))
+    .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
+    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.2.0"))
   ],
   targets: [
     .target(

--- a/Sources/Carlos/CacheLevels/BatchAllCache.swift
+++ b/Sources/Carlos/CacheLevels/BatchAllCache.swift
@@ -42,6 +42,15 @@ public final class BatchAllCache<KeySeq: Sequence, Cache: CacheLevel>: CacheLeve
       }
   }
 
+  public func remove(_ key: KeyType) -> AnyPublisher<Void, Error> {
+    let all = key.map(cache.remove)
+    return all.publisher
+      .setFailureType(to: Error.self)
+      .collect(all.count)
+      .map { _ in () }
+      .eraseToAnyPublisher()
+  }
+
   public func clear() {
     cache.clear()
   }

--- a/Sources/Carlos/CacheLevels/Composed.swift
+++ b/Sources/Carlos/CacheLevels/Composed.swift
@@ -35,6 +35,11 @@ extension CacheLevel {
         .map { _ in () }
         .eraseToAnyPublisher()
       },
+      removeClosure: { key in
+        Publishers.Zip(self.remove(key), cache.remove(key))
+          .map { _ in () }
+          .eraseToAnyPublisher()
+      },
       clearClosure: {
         self.clear()
         cache.clear()

--- a/Sources/Carlos/CacheLevels/Conditioned.swift
+++ b/Sources/Carlos/CacheLevels/Conditioned.swift
@@ -15,6 +15,7 @@ extension CacheLevel {
     BasicCache(
       getClosure: conditionedClosure(get, condition: condition),
       setClosure: set,
+      removeClosure: remove,
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Sources/Carlos/CacheLevels/DiskCacheLevel.swift
+++ b/Sources/Carlos/CacheLevels/DiskCacheLevel.swift
@@ -117,6 +117,29 @@ public final class DiskCacheLevel<K: StringConvertible, T: NSCoding>: CacheLevel
     .eraseToAnyPublisher()
   }
 
+  public func remove(_ key: K) -> AnyPublisher<Void, Error> {
+    AnyPublisher.create { [weak self] promise in
+      guard let path = self?.pathForKey(key) else {
+        return
+      }
+
+      do {
+        Logger.log("DiskCacheLevel| Removing \(key.toString()) at path: \(path) on the disk cache", .info)
+        try self?.fileManager.removeItem(atPath: path)
+
+        self?.calculateSize()
+
+        promise(.success(()))
+      } catch {
+        Logger.log("DiskCacheLevel| Failed to remove \(key.toString()) at path: \(path) on the disk cache", .error)
+
+        promise(.failure(error))
+      }
+    }
+    .subscribe(on: cacheQueue)
+    .eraseToAnyPublisher()
+  }
+
   /**
    Asynchronously clears the contents of the cache
 

--- a/Sources/Carlos/CacheLevels/DiskCacheLevel.swift
+++ b/Sources/Carlos/CacheLevels/DiskCacheLevel.swift
@@ -53,7 +53,7 @@ public final class DiskCacheLevel<K: StringConvertible, T: NSCoding>: CacheLevel
 
     _ = try? fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: [:])
 
-    cacheQueue.async { () -> Void in
+    cacheQueue.async {
       self.calculateSize()
       self.controlCapacity()
     }
@@ -146,7 +146,7 @@ public final class DiskCacheLevel<K: StringConvertible, T: NSCoding>: CacheLevel
    All the cached files will be removed from the disk storage
    */
   public func clear() {
-    cacheQueue.async { () -> Void in
+    cacheQueue.async {
       self.itemsInDirectory(self.path).forEach { filePath in
         _ = try? self.fileManager.removeItem(atPath: filePath)
       }

--- a/Sources/Carlos/CacheLevels/Fetcher.swift
+++ b/Sources/Carlos/CacheLevels/Fetcher.swift
@@ -14,6 +14,11 @@ public protocol Fetcher: CacheLevel {}
 /// Extending the Fetcher protocol to have a default no-op implementation for clear, onMemoryWarning and set
 extension Fetcher {
   /// No-op
+  public func remove(_ key: KeyType) -> AnyPublisher<Void, Error> {
+    Empty(completeImmediately: true).eraseToAnyPublisher()
+  }
+
+  /// No-op
   public func clear() {}
 
   /// No-op

--- a/Sources/Carlos/CacheLevels/MemoryCacheLevel.swift
+++ b/Sources/Carlos/CacheLevels/MemoryCacheLevel.swift
@@ -39,6 +39,16 @@ public final class MemoryCacheLevel<K: StringConvertible, T: AnyObject>: CacheLe
     .eraseToAnyPublisher()
   }
 
+  public func remove(_ key: K) -> AnyPublisher<Void, Error> {
+    AnyPublisher.create { [weak self] promise in
+      Logger.log("MemoryCacheLevel| Removing \(key.toString()) on memory level.", .info)
+
+      self?.internalCache.removeObject(forKey: key.toString() as NSString)
+      
+      promise(.success(()))
+    }
+  }
+
   /**
    Clears the contents of the cache
    */
@@ -53,12 +63,11 @@ public final class MemoryCacheLevel<K: StringConvertible, T: AnyObject>: CacheLe
    - parameter key: The key for the value
    */
   public func set(_ value: T, forKey key: K) -> AnyPublisher<Void, Error> {
-    Logger.log("MemoryCacheLevel| Setting a value for the key \(key.toString()) on the memory cache \(self).", .info)
-    internalCache.setObject(value, forKey: key.toString() as NSString, cost: value.cost)
+    AnyPublisher.create { [weak self] promise in
+      self?.internalCache.setObject(value, forKey: key.toString() as NSString, cost: value.cost)
 
-    return Just(())
-      .setFailureType(to: Error.self)
-      .eraseToAnyPublisher()
+      promise(.success(()))
+    }
   }
 
   /**

--- a/Sources/Carlos/CacheLevels/NSUserDefaultsCacheLevel.swift
+++ b/Sources/Carlos/CacheLevels/NSUserDefaultsCacheLevel.swift
@@ -111,6 +111,13 @@ public final class NSUserDefaultsCacheLevel<K: StringConvertible, T: NSCoding>: 
     .eraseToAnyPublisher()
   }
 
+  public func remove(_ key: K) -> AnyPublisher<Void, Error> {
+    AnyPublisher.create { [weak self] promise in
+      self?.userDefaults.removeObject(forKey: key.toString())
+      promise(.success(()))
+    }
+  }
+
   /**
    Completely clears the contents of this cache
 

--- a/Sources/Carlos/CacheLevels/PoolCache.swift
+++ b/Sources/Carlos/CacheLevels/PoolCache.swift
@@ -69,6 +69,10 @@ public final class PoolCache<C: CacheLevel>: CacheLevel where C.KeyType: Hashabl
     internalCache.set(value, forKey: key)
   }
 
+  public func remove(_ key: C.KeyType) -> AnyPublisher<Void, Error> {
+    internalCache.remove(key)
+  }
+
   /// Clears the managed cache
   public func clear() {
     internalCache.clear()

--- a/Sources/Carlos/CacheLevels/PoolCache.swift
+++ b/Sources/Carlos/CacheLevels/PoolCache.swift
@@ -53,9 +53,9 @@ public final class PoolCache<C: CacheLevel>: CacheLevel where C.KeyType: Hashabl
     Logger.log("Creating a new request \(request) for key \(key)")
 
     return request
-      .handleEvents(receiveCompletion: { _ in
-        self.lock.locked {
-          self.requestsPool[key] = nil
+      .handleEvents(receiveCompletion: { [weak self] _ in
+        self?.lock.locked {
+          self?.requestsPool[key] = nil
         }
       })
       .eraseToAnyPublisher()

--- a/Sources/Carlos/Carlos.swift
+++ b/Sources/Carlos/Carlos.swift
@@ -29,6 +29,8 @@ public protocol CacheLevel: AnyObject {
   /// - Returns: A `Publisher that will reflect the status of the set operation
   func set(_ value: OutputType, forKey key: KeyType) -> AnyPublisher<Void, Error>
 
+  func remove(_ key: KeyType) -> AnyPublisher<Void, Error>
+
   /// Asks to clear the cache level
   func clear()
 

--- a/Sources/Carlos/Carlos.swift
+++ b/Sources/Carlos/Carlos.swift
@@ -26,9 +26,14 @@ public protocol CacheLevel: AnyObject {
   /// - Parameter value: The bytes to set on the cache level
   /// - Parameter key: The key of the value you're trying to set
   ///
-  /// - Returns: A `Publisher that will reflect the status of the set operation
+  /// - Returns: A `Publisher` that will reflect the status of the set operation
   func set(_ value: OutputType, forKey key: KeyType) -> AnyPublisher<Void, Error>
 
+  /// Remove value from cache for a given key.
+  ///
+  /// - Parameter key: They key of the value to be removed
+  ///
+  /// - Returns: A `Publisher` that reflects a status of the remove operation.
   func remove(_ key: KeyType) -> AnyPublisher<Void, Error>
 
   /// Asks to clear the cache level

--- a/Sources/Carlos/Core/BasicCache.swift
+++ b/Sources/Carlos/Core/BasicCache.swift
@@ -8,6 +8,7 @@ public final class BasicCache<A, B>: CacheLevel {
 
   private let getClosure: (_ key: A) -> AnyPublisher<B, Error>
   private let setClosure: (_ value: B, _ key: A) -> AnyPublisher<Void, Error>
+  private let removeClosure: (_ key: A) -> AnyPublisher<Void, Error>
   private let clearClosure: () -> Void
   private let memoryClosure: () -> Void
 
@@ -22,11 +23,13 @@ public final class BasicCache<A, B>: CacheLevel {
   public init(
     getClosure: @escaping (_ key: A) -> AnyPublisher<B, Error>,
     setClosure: @escaping (_ value: B, _ key: A) -> AnyPublisher<Void, Error>,
+    removeClosure: @escaping (_ key: A) -> AnyPublisher<Void, Error>,
     clearClosure: @escaping () -> Void,
     memoryClosure: @escaping () -> Void
   ) {
     self.getClosure = getClosure
     self.setClosure = setClosure
+    self.removeClosure = removeClosure
     self.clearClosure = clearClosure
     self.memoryClosure = memoryClosure
   }
@@ -52,6 +55,10 @@ public final class BasicCache<A, B>: CacheLevel {
    */
   public func set(_ value: B, forKey key: A) -> AnyPublisher<Void, Error> {
     setClosure(value, key)
+  }
+
+  public func remove(_ key: A) -> AnyPublisher<Void, Error> {
+    removeClosure(key)
   }
 
   /**

--- a/Sources/Carlos/Core/FetcherValueTransformation.swift
+++ b/Sources/Carlos/Core/FetcherValueTransformation.swift
@@ -13,8 +13,12 @@ extension Fetcher {
    */
   public func transformValues<A: OneWayTransformer>(_ transformer: A) -> BasicFetcher<KeyType, A.TypeOut> where OutputType == A.TypeIn {
     BasicFetcher(
-      getClosure: { key in
-        self.get(key)
+      getClosure: { [weak self] key in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return self.get(key)
           .flatMap(transformer.transform)
           .eraseToAnyPublisher()
       }

--- a/Sources/Carlos/Operations/KeyTransformation.swift
+++ b/Sources/Carlos/Operations/KeyTransformation.swift
@@ -25,6 +25,11 @@ extension CacheLevel {
           }
           .eraseToAnyPublisher()
       },
+      removeClosure: {
+        transformer.transform($0)
+          .flatMap(self.remove)
+          .eraseToAnyPublisher()
+      },
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Sources/Carlos/Operations/KeyTransformation.swift
+++ b/Sources/Carlos/Operations/KeyTransformation.swift
@@ -13,20 +13,32 @@ extension CacheLevel {
    */
   public func transformKeys<A: OneWayTransformer>(_ transformer: A) -> BasicCache<A.TypeIn, OutputType> where KeyType == A.TypeOut {
     BasicCache(
-      getClosure: { key in
-        transformer.transform(key)
+      getClosure: { [weak self] key in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return transformer.transform(key)
           .flatMap(self.get)
           .eraseToAnyPublisher()
       },
-      setClosure: { value, key in
-        transformer.transform(key)
+      setClosure: { [weak self] value, key in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return transformer.transform(key)
           .flatMap { transformedKey in
             self.set(value, forKey: transformedKey)
           }
           .eraseToAnyPublisher()
       },
-      removeClosure: {
-        transformer.transform($0)
+      removeClosure: { [weak self] in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return transformer.transform($0)
           .flatMap(self.remove)
           .eraseToAnyPublisher()
       },

--- a/Sources/Carlos/Operations/Normalize.swift
+++ b/Sources/Carlos/Operations/Normalize.swift
@@ -14,6 +14,7 @@ extension CacheLevel {
       return BasicCache<KeyType, OutputType>(
         getClosure: get,
         setClosure: set,
+        removeClosure: remove,
         clearClosure: clear,
         memoryClosure: onMemoryWarning
       )

--- a/Sources/Carlos/Operations/PostProcess.swift
+++ b/Sources/Carlos/Operations/PostProcess.swift
@@ -18,6 +18,7 @@ extension CacheLevel {
           .eraseToAnyPublisher()
       },
       setClosure: set,
+      removeClosure: remove,
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Sources/Carlos/Operations/SwitchCache.swift
+++ b/Sources/Carlos/Operations/SwitchCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// Convenience enumeration to specify which of two switched cache levels should be used for a get or set operation
 public enum CacheLevelSwitchResult {
@@ -35,6 +36,11 @@ public func switchLevels<A: CacheLevel, B: CacheLevel>(cacheA: A, cacheB: B, swi
       case .cacheB:
         return cacheB.set(value, forKey: key)
       }
+    },
+    removeClosure: {
+      Publishers.Zip(cacheA.remove($0), cacheB.remove($0))
+        .map { _ in () }
+        .eraseToAnyPublisher()
     },
     clearClosure: {
       cacheA.clear()

--- a/Sources/Carlos/Operations/ValueTransformation.swift
+++ b/Sources/Carlos/Operations/ValueTransformation.swift
@@ -25,6 +25,7 @@ extension CacheLevel {
           }
           .eraseToAnyPublisher()
       },
+      removeClosure: remove,
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Sources/Carlos/Operations/ValueTransformation.swift
+++ b/Sources/Carlos/Operations/ValueTransformation.swift
@@ -13,13 +13,21 @@ extension CacheLevel {
    */
   public func transformValues<A: TwoWayTransformer>(_ transformer: A) -> BasicCache<KeyType, A.TypeOut> where OutputType == A.TypeIn {
     BasicCache(
-      getClosure: { key in
-        self.get(key)
+      getClosure: { [weak self] key in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return self.get(key)
           .flatMap(transformer.transform)
           .eraseToAnyPublisher()
       },
-      setClosure: { value, key in
-        transformer.inverseTransform(value)
+      setClosure: { [weak self] value, key in
+        guard let self = self else {
+          return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+
+        return transformer.inverseTransform(value)
           .flatMap { transformedValue in
             self.set(transformedValue, forKey: key)
           }

--- a/Sources/Carlos/Transformers/ConditionedOutputProcessing.swift
+++ b/Sources/Carlos/Transformers/ConditionedOutputProcessing.swift
@@ -20,6 +20,7 @@ extension CacheLevel {
           .eraseToAnyPublisher()
       },
       setClosure: set,
+      removeClosure: remove,
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Sources/Carlos/Transformers/ConditionedValueTransformation.swift
+++ b/Sources/Carlos/Transformers/ConditionedValueTransformation.swift
@@ -27,6 +27,7 @@ extension CacheLevel {
           }
           .eraseToAnyPublisher()
       },
+      removeClosure: remove,
       clearClosure: clear,
       memoryClosure: onMemoryWarning
     )

--- a/Tests/CarlosTests/BasicCacheTests.swift
+++ b/Tests/CarlosTests/BasicCacheTests.swift
@@ -19,11 +19,15 @@ final class BasicCacheTests: QuickSpec {
       var numberOfTimesCalledOnMemoryWarning = 0
       var numberOfTimesCalledGet = 0
       var numberOfTimesCalledSet = 0
+      var numberOfTimesCalledRemove = 0
       var didSetKey: String?
       var didSetValue: Int?
       var didGetKey: String?
+      var removeKey: String?
+      
       var getSubject: PassthroughSubject<Int, Error>!
       var setSubject: PassthroughSubject<Void, Error>!
+      var removeSubject: PassthroughSubject<Void, Error>!
 
       var cancellable: AnyCancellable?
 
@@ -49,6 +53,11 @@ final class BasicCacheTests: QuickSpec {
             numberOfTimesCalledSet += 1
 
             return setSubject.eraseToAnyPublisher()
+          },
+          removeClosure: { key in
+            numberOfTimesCalledRemove += 1
+            removeKey = key
+            return removeSubject.eraseToAnyPublisher()
           },
           clearClosure: {
             numberOfTimesCalledClear += 1

--- a/Tests/CarlosTests/DiskCacheTests.swift
+++ b/Tests/CarlosTests/DiskCacheTests.swift
@@ -221,6 +221,31 @@ final class DiskCacheTests: QuickSpec {
           }
         }
 
+        context("when calling remove") {
+          var result = false
+          let key = "test-key"
+
+          beforeEach {
+            result = false
+
+            cache.clear()
+          }
+
+          it("shall remove object from cache for given key") {
+            cache.set("value".data(using: .utf8)! as NSData, forKey: key)
+              .flatMap { cache.remove(key) }
+              .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { _ in
+                  result = true
+                }
+              )
+              .store(in: &cancellables)
+
+            expect(result).toEventually(beTrue())
+          }
+        }
+
         context("when calling clear") {
           beforeEach {
             result = nil

--- a/Tests/CarlosTests/Fakes/CacheLevelFake.swift
+++ b/Tests/CarlosTests/Fakes/CacheLevelFake.swift
@@ -7,6 +7,10 @@ class CacheLevelFake<A: Hashable, B>: CacheLevel {
   typealias KeyType = A
   typealias OutputType = B
 
+  var numberOfTimesRemoveCalled = 0
+  var removeKey: KeyType?
+  var removeSubject: PassthroughSubject<Void, Error>!
+
   init() {}
 
   // MARK: Get
@@ -60,11 +64,23 @@ class CacheLevelFake<A: Hashable, B>: CacheLevel {
     return newSubject.eraseToAnyPublisher()
   }
 
+  // MARK: - Remove
+
+  func remove(_ key: A) -> AnyPublisher<Void, Error> {
+    numberOfTimesRemoveCalled += 1
+    removeKey = key
+
+    return removeSubject.eraseToAnyPublisher()
+  }
+
+  // MARK: - Clear
+
   var numberOfTimesCalledClear = 0
   func clear() {
     numberOfTimesCalledClear += 1
   }
 
+  // MARK: - On Memory Warning
   var numberOfTimesCalledOnMemoryWarning = 0
   func onMemoryWarning() {
     numberOfTimesCalledOnMemoryWarning += 1

--- a/Tests/CarlosTests/NSUserDefaultsCacheLevelTests.swift
+++ b/Tests/CarlosTests/NSUserDefaultsCacheLevelTests.swift
@@ -161,8 +161,33 @@ final class NSUserDefaultsCacheLevelTests: QuickSpec {
             }
 
             it("should succeed with the overwritten value") {
-              expect(result).toEventually(equal(newValue as NSString), timeout: 5)
+              expect(result).toEventually(equal(newValue as NSString), timeout: .seconds(5))
             }
+          }
+        }
+
+        context("when calling remove") {
+          var result = false
+          let key = "test-key"
+
+          beforeEach {
+            result = false
+
+            cache.clear()
+          }
+
+          it("shall remove object from cache for given key") {
+            cache.set("value", forKey: key)
+              .flatMap { cache.remove(key) }
+              .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { _ in
+                  result = true
+                }
+              )
+              .store(in: &cancellables)
+
+            expect(result).toEventually(beTrue())
           }
         }
 

--- a/Tests/CarlosTests/NetworkFetcherTests.swift
+++ b/Tests/CarlosTests/NetworkFetcherTests.swift
@@ -47,7 +47,7 @@ final class NetworkFetcherTests: QuickSpec {
         }
 
         it("should complete all requests") {
-          expect(finished).toEventually(equal(simultaneousRequests), timeout: 10)
+          expect(finished).toEventually(equal(simultaneousRequests), timeout: .seconds(10))
         }
       }
     }


### PR DESCRIPTION
## Context
This PR implements a feature request from the issue #193. We indeed don't provide a way to remove a value for specific key from a cache and it kinda does make sense to have this functionality. 

## Changes
- Add `remove(_ key: Key)` method to `CacheLevel` protocol 
- Implement the newly added method in the cache levels 
- Add unit tests for the newly added method
- Upgrade Quick & Nimble to 4.0.0 and 9.2.0 